### PR TITLE
fix: deposit tx rlp decode

### DIFF
--- a/crates/consensus/src/transaction/deposit.rs
+++ b/crates/consensus/src/transaction/deposit.rs
@@ -59,7 +59,12 @@ pub struct TxDeposit {
     /// msg.To.
     #[cfg_attr(
         feature = "serde",
-        serde(default, with = "alloy_serde::quantity::opt", rename = "ethTxValue", skip_serializing_if = "Option::is_none")
+        serde(
+            default,
+            with = "alloy_serde::quantity::opt",
+            rename = "ethTxValue",
+            skip_serializing_if = "Option::is_none"
+        )
     )]
     pub eth_tx_value: Option<u128>,
 }
@@ -108,7 +113,6 @@ impl TxDeposit {
     /// Decodes a u128 value from RLP format. If the value doesn't exist, the field will be omitted
     /// from encoding.
     pub fn decode_optional_u128_from_rlp(buf: &mut &[u8]) -> Result<Option<u128>, DecodeError> {
-        println!("buf: {:x?}", buf);
         if buf.is_empty() {
             return Ok(None);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
When the imported block contains multiple transactions, if the ethTxValue of the first depositTx is 0, it will be ignored. However, here a u128 is forced to be decoded, which will cause a decoding error.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The solution is to check if the subsequent data is of type u128 and decode it if it is. Otherwise, do not decode it.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
