### PR TITLE
V230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2](https://github.com/alloy-rs/op-alloy
+/releases/tag/v0.22.2) - 2025-11-18
+
+### Features
+
+- Add bincode compat to OpReceipt ([#608](https://github.com/alloy-rs/op-alloy/issues/608))
+
 ## [0.22.1](https://github.com/alloy-rs/op-alloy
 /releases/tag/v0.22.1) - 2025-11-11
 
@@ -15,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 
 - [flashblock] Commit shared flashblock data structures ([#606](https://github.com/alloy-rs/op-alloy/issues/606))
+
+### Miscellaneous Tasks
+
+- Release 0.22.1
 
 ## [0.22.0](https://github.com/alloy-rs/op-alloy
 /releases/tag/v0.22.0) - 2025-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.3](https://github.com/alloy-rs/op-alloy
+/releases/tag/v0.22.3) - 2025-11-19
+
+### Miscellaneous Tasks
+
+- [op-alloy] Update blob gas used serialization method ([#609](https://github.com/alloy-rs/op-alloy/issues/609))
+
 ## [0.22.2](https://github.com/alloy-rs/op-alloy
 /releases/tag/v0.22.2) - 2025-11-18
 
 ### Features
 
 - Add bincode compat to OpReceipt ([#608](https://github.com/alloy-rs/op-alloy/issues/608))
+
+### Miscellaneous Tasks
+
+- Release 0.22.2
 
 ## [0.22.1](https://github.com/alloy-rs/op-alloy
 /releases/tag/v0.22.1) - 2025-11-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0](https://github.com/alloy-rs/op-alloy
+/releases/tag/v0.23.0) - 2025-12-08
+
+### Bug Fixes
+
+- Correct `OpReceipt` rlp ([#612](https://github.com/alloy-rs/op-alloy/issues/612))
+
+### Features
+
+- [consensus] Add L2ToL1MessagePasser predeploy address ([#614](https://github.com/alloy-rs/op-alloy/issues/614))
+- Add helpers for recovering txs from flashblocks ([#611](https://github.com/alloy-rs/op-alloy/issues/611))
+- Use `OpReceipt` as `ReceiptEnvelope` for OP network ([#610](https://github.com/alloy-rs/op-alloy/issues/610))
+
+### Miscellaneous Tasks
+
+- [rpc-types-engine] Upstream `payloadID` computation to `op-alloy` ([#613](https://github.com/alloy-rs/op-alloy/issues/613))
+
 ## [0.22.3](https://github.com/alloy-rs/op-alloy
 /releases/tag/v0.22.3) - 2025-11-19
 
 ### Miscellaneous Tasks
 
+- Release 0.22.3
 - [op-alloy] Update blob gas used serialization method ([#609](https://github.com/alloy-rs/op-alloy/issues/609))
 
 ## [0.22.2](https://github.com/alloy-rs/op-alloy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ derive_more = { version = "2.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 similar-asserts = "1.7"
 
+# hashing
+sha2 = { version = "0.10", default-features = false }
+
 # tracing
 tracing-subscriber = "0.3.19"
 tracing = { version = "0.1.41", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.1"
+version = "0.22.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Alloy Contributors"]
@@ -37,12 +37,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # Workspace
-op-alloy-consensus = { version = "0.22.1", path = "crates/consensus", default-features = false }
-op-alloy-network = { version = "0.22.1", path = "crates/network", default-features = false }
-op-alloy-provider = { version = "0.22.1", path = "crates/provider", default-features = false }
-op-alloy-rpc-types = { version = "0.22.1", path = "crates/rpc-types", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.1", path = "crates/rpc-types-engine", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.22.1", path = "crates/rpc-jsonrpsee", default-features = false }
+op-alloy-consensus = { version = "0.22.2", path = "crates/consensus", default-features = false }
+op-alloy-network = { version = "0.22.2", path = "crates/network", default-features = false }
+op-alloy-provider = { version = "0.22.2", path = "crates/provider", default-features = false }
+op-alloy-rpc-types = { version = "0.22.2", path = "crates/rpc-types", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.22.2", path = "crates/rpc-types-engine", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.22.2", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # Alloy
 alloy-eips = { version = "1.0.41", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,17 @@ op-alloy-rpc-types-engine = { version = "0.22.3", path = "crates/rpc-types-engin
 op-alloy-rpc-jsonrpsee = { version = "0.22.3", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # Alloy
-alloy-eips = { version = "1.0.41", default-features = false }
-alloy-serde = { version = "1.0.41", default-features = false }
-alloy-signer = { version = "1.0.41", default-features = false }
-alloy-network = { version = "1.0.41", default-features = false }
-alloy-provider = { version = "1.0.41", default-features = false }
-alloy-transport = { version = "1.0.41", default-features = false }
-alloy-consensus = { version = "1.0.41", default-features = false }
-alloy-rpc-types-eth = { version = "1.0.41", default-features = false }
-alloy-rpc-types-engine = { version = "1.0.41", default-features = false }
-alloy-network-primitives = { version = "1.0.41", default-features = false }
-alloy-json-rpc = { version = "1.0.41", default-features = false }
+alloy-eips = { version = "1.1.2", default-features = false }
+alloy-serde = { version = "1.1.2", default-features = false }
+alloy-signer = { version = "1.1.2", default-features = false }
+alloy-network = { version = "1.1.2", default-features = false }
+alloy-provider = { version = "1.1.2", default-features = false }
+alloy-transport = { version = "1.1.2", default-features = false }
+alloy-consensus = { version = "1.1.2", default-features = false }
+alloy-rpc-types-eth = { version = "1.1.2", default-features = false }
+alloy-rpc-types-engine = { version = "1.1.2", default-features = false }
+alloy-network-primitives = { version = "1.1.2", default-features = false }
+alloy-json-rpc = { version = "1.1.2", default-features = false }
 
 # Alloy RLP
 alloy-rlp = { version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.3"
+version = "0.23.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Alloy Contributors"]
@@ -37,12 +37,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # Workspace
-op-alloy-consensus = { version = "0.22.3", path = "crates/consensus", default-features = false }
-op-alloy-network = { version = "0.22.3", path = "crates/network", default-features = false }
-op-alloy-provider = { version = "0.22.3", path = "crates/provider", default-features = false }
-op-alloy-rpc-types = { version = "0.22.3", path = "crates/rpc-types", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.3", path = "crates/rpc-types-engine", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.22.3", path = "crates/rpc-jsonrpsee", default-features = false }
+op-alloy-consensus = { version = "0.23.0", path = "crates/consensus", default-features = false }
+op-alloy-network = { version = "0.23.0", path = "crates/network", default-features = false }
+op-alloy-provider = { version = "0.23.0", path = "crates/provider", default-features = false }
+op-alloy-rpc-types = { version = "0.23.0", path = "crates/rpc-types", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.23.0", path = "crates/rpc-types-engine", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.23.0", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # Alloy
 alloy-eips = { version = "1.1.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.2"
+version = "0.22.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Alloy Contributors"]
@@ -37,12 +37,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # Workspace
-op-alloy-consensus = { version = "0.22.2", path = "crates/consensus", default-features = false }
-op-alloy-network = { version = "0.22.2", path = "crates/network", default-features = false }
-op-alloy-provider = { version = "0.22.2", path = "crates/provider", default-features = false }
-op-alloy-rpc-types = { version = "0.22.2", path = "crates/rpc-types", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.2", path = "crates/rpc-types-engine", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.22.2", path = "crates/rpc-jsonrpsee", default-features = false }
+op-alloy-consensus = { version = "0.22.3", path = "crates/consensus", default-features = false }
+op-alloy-network = { version = "0.22.3", path = "crates/network", default-features = false }
+op-alloy-provider = { version = "0.22.3", path = "crates/provider", default-features = false }
+op-alloy-rpc-types = { version = "0.22.3", path = "crates/rpc-types", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.22.3", path = "crates/rpc-types-engine", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.22.3", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # Alloy
 alloy-eips = { version = "1.0.41", default-features = false }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -37,6 +37,9 @@ pub use block::OpBlock;
 
 pub mod interop;
 
+pub mod predeploys;
+pub use predeploys::L2_TO_L1_MESSAGE_PASSER_ADDRESS;
+
 #[cfg(feature = "serde")]
 pub use transaction::serde_deposit_tx_rpc;
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -50,7 +50,10 @@ pub use transaction::serde_deposit_tx_rpc;
 #[cfg(all(feature = "serde", feature = "serde-bincode-compat"))]
 pub mod serde_bincode_compat {
     pub use super::{
-        receipts::deposit::serde_bincode_compat::OpDepositReceipt,
+        receipts::{
+            deposit::serde_bincode_compat::OpDepositReceipt,
+            receipt::serde_bincode_compat::OpReceipt,
+        },
         transaction::{serde_bincode_compat as transaction, serde_bincode_compat::TxDeposit},
     };
 }

--- a/crates/consensus/src/predeploys.rs
+++ b/crates/consensus/src/predeploys.rs
@@ -1,0 +1,7 @@
+//! Addresses of OP Stack pre-deployed contracts.
+
+use alloy_primitives::{Address, address};
+
+/// The address of the `L2ToL1MessagePasser` predeploy.
+pub const L2_TO_L1_MESSAGE_PASSER_ADDRESS: Address =
+    address!("0x4200000000000000000000000000000000000016");

--- a/crates/consensus/src/receipts/mod.rs
+++ b/crates/consensus/src/receipts/mod.rs
@@ -8,7 +8,7 @@ pub use envelope::OpReceiptEnvelope;
 pub(crate) mod deposit;
 pub use deposit::{OpDepositReceipt, OpDepositReceiptWithBloom};
 
-mod receipt;
+pub(crate) mod receipt;
 pub use receipt::OpReceipt;
 
 /// Receipt is the result of a transaction execution.

--- a/crates/consensus/src/receipts/receipt.rs
+++ b/crates/consensus/src/receipts/receipt.rs
@@ -495,7 +495,7 @@ pub(crate) mod serde_bincode_compat {
 
     #[cfg(test)]
     mod tests {
-        use crate::{OpReceipt, receipt::serde_bincode_compat};
+        use crate::OpReceipt;
         use arbitrary::Arbitrary;
         use rand::Rng;
         use serde::{Deserialize, Serialize};
@@ -506,7 +506,7 @@ pub(crate) mod serde_bincode_compat {
             #[serde_as]
             #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
             struct Data {
-                #[serde_as(as = "serde_bincode_compat::OpReceipt<'_>")]
+                #[serde_as(as = "super::OpReceipt<'_>")]
                 receipt: OpReceipt,
             }
 
@@ -519,8 +519,10 @@ pub(crate) mod serde_bincode_compat {
             // // ensure we don't have an invalid poststate variant
             data.receipt.as_receipt_mut().status = success.into();
 
-            let encoded = bincode::serialize(&data).unwrap();
-            let decoded: Data = bincode::deserialize(&encoded).unwrap();
+            let encoded = bincode::serde::encode_to_vec(&data, bincode::config::legacy()).unwrap();
+            let (decoded, _) =
+                bincode::serde::decode_from_slice::<Data, _>(&encoded, bincode::config::legacy())
+                    .unwrap();
             assert_eq!(decoded, data);
         }
     }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -8,10 +8,10 @@
 
 pub use alloy_network::*;
 
-use alloy_consensus::{TxEnvelope, TxType, TypedTransaction};
+use alloy_consensus::{ReceiptWithBloom, TxEnvelope, TxType, TypedTransaction};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::AccessList;
-use op_alloy_consensus::{OpTxEnvelope, OpTxType, OpTypedTransaction};
+use op_alloy_consensus::{OpReceipt, OpTxEnvelope, OpTxType, OpTypedTransaction};
 use op_alloy_rpc_types::OpTransactionRequest;
 
 /// Types for an Op-stack network.
@@ -27,7 +27,7 @@ impl Network for Optimism {
 
     type UnsignedTx = op_alloy_consensus::OpTypedTransaction;
 
-    type ReceiptEnvelope = op_alloy_consensus::OpReceiptEnvelope;
+    type ReceiptEnvelope = ReceiptWithBloom<OpReceipt>;
 
     type Header = alloy_consensus::Header;
 

--- a/crates/rpc-types-engine/Cargo.toml
+++ b/crates/rpc-types-engine/Cargo.toml
@@ -38,6 +38,9 @@ alloy-serde = { workspace = true, optional = true }
 thiserror.workspace = true
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
+# hashing
+sha2.workspace = true
+
 derive_more = { workspace = true, features = ["as_ref", "deref_mut"] }
 
 [dev-dependencies]

--- a/crates/rpc-types-engine/src/flashblock/delta.rs
+++ b/crates/rpc-types-engine/src/flashblock/delta.rs
@@ -32,7 +32,14 @@ pub struct OpFlashblockPayloadDelta {
     /// The estimated cumulative blob gas used for the block. Introduced in Jovian.
     /// spec: <https://docs.optimism.io/notices/upgrade-17#block-header-changes>
     /// Defaults to 0 if not present (for pre-Jovian blocks).
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "alloy_serde::quantity::opt"
+        )
+    )]
     pub blob_gas_used: Option<u64>,
 }
 
@@ -158,7 +165,7 @@ mod tests {
         let json = serde_json::to_string(&delta).unwrap();
         // Should contain blob_gas_used when Some
         assert!(json.contains("blob_gas_used"));
-        assert!(json.contains("12345"));
+        assert!(json.contains("0x3039"));
     }
 
     #[test]

--- a/crates/rpc-types/src/receipt.rs
+++ b/crates/rpc-types/src/receipt.rs
@@ -1,8 +1,11 @@
 //! Receipt types for RPC
 
-use alloy_consensus::{Receipt, ReceiptWithBloom};
+use alloy_consensus::{Receipt, ReceiptWithBloom, TxReceipt};
+use alloy_rpc_types_eth::Log;
 use alloy_serde::OtherFields;
-use op_alloy_consensus::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope};
+use op_alloy_consensus::{
+    OpDepositReceipt, OpDepositReceiptWithBloom, OpReceipt, OpReceiptEnvelope,
+};
 use serde::{Deserialize, Serialize};
 
 /// OP Transaction Receipt type
@@ -12,7 +15,7 @@ use serde::{Deserialize, Serialize};
 pub struct OpTransactionReceipt {
     /// Regular eth transaction receipt including deposit receipts
     #[serde(flatten)]
-    pub inner: alloy_rpc_types_eth::TransactionReceipt<OpReceiptEnvelope<alloy_rpc_types_eth::Log>>,
+    pub inner: alloy_rpc_types_eth::TransactionReceipt<ReceiptWithBloom<OpReceipt<Log>>>,
     /// L1 block info of the transaction.
     #[serde(flatten)]
     pub l1_block_info: L1BlockInfo,
@@ -200,7 +203,7 @@ impl Eq for L1BlockInfo {}
 
 impl From<OpTransactionReceipt> for OpReceiptEnvelope<alloy_primitives::Log> {
     fn from(value: OpTransactionReceipt) -> Self {
-        let inner_envelope = value.inner.inner;
+        let inner_envelope = value.inner.inner.into();
 
         /// Helper function to convert the inner logs within a [ReceiptWithBloom] from RPC to
         /// consensus types.


### PR DESCRIPTION
## Motivation

This PR proposes a controlled merge of `v230` into `main` to bring `mantle-xyz/op-alloy` in line with the upstream OP evolution while preserving Mantle-specific integration continuity.

From a release-governance and audit perspective, this merge addresses three priorities:

1. **Protocol correctness alignment**  
   Incorporate upstream OP receipt/serialization and consensus-adjacent updates that are already validated in the `v230` branch line.

2. **Operational risk reduction**  
   Eliminate prolonged branch drift between `main` and `v230`, which increases maintenance overhead and raises the risk of silent behavioral divergence in downstream consumers.

3. **Traceability and provenance**  
   Integrate upstream-derived commits and Mantle follow-ups via branch merge (not fragmented cherry-picks), preserving commit ancestry and making future forensic review/rebase work more reliable.

## Solution

This PR performs a branch-level merge of `v230` into `main`, carrying the full set of upstream and Mantle synchronization commits in a single auditable integration step.

### Scope of integrated changes

- OP receipt model and compatibility updates (including bincode/serialization and RLP correctness fixes).
- Network-level receipt response behavior updates for OP paths.
- Consensus/predeploy/helper updates included in the `v230` line.
- Mantle synchronization commits and associated test refreshes.

### Integration methodology

- **Merge strategy:** branch merge to retain history fidelity and upstream provenance.
- **Change integrity:** no selective omission of `v230` commits during integration.
- **Reviewability:** commit lineage remains intact for targeted blame, bisect, and post-merge audits.

### Risk notes

Potential downstream impact areas (to be explicitly validated by consumers):
- Receipt encoding/decoding assumptions.
- RPC schema/typing expectations around OP receipts.
- Any custom tooling relying on legacy receipt-envelope behavior.

No additional speculative refactors are introduced beyond the merged branch content.


### Breaking-change disclosure

This merge includes behavior and type-surface updates in OP receipt handling inherited from `v230`.  
Downstream integrators should treat this as a breaking upgrade and complete compatibility verification before production rollout.